### PR TITLE
Fixing Exception with empty manufacturer

### DIFF
--- a/WebMIDIAPIPolyfill/WebViewDelegate.m
+++ b/WebMIDIAPIPolyfill/WebViewDelegate.m
@@ -42,8 +42,8 @@ static NSString *kURLScheme_RequestSend  = @"webmidi-send://";
     
     NSDictionary *portInfo = @{ @"id"           : [NSNumber numberWithInt:uniqueId],
                                 @"version"      : [NSNumber numberWithInt:version],
-                                @"manufacturer" : (__bridge NSString *)manufacturer,
-                                @"name"         : (__bridge NSString *)name,
+                                @"manufacturer" : ((__bridge NSString *)manufacturer ?: @""),
+                                @"name"         : ((__bridge NSString *)name ?: @""),
                               };
     
     return portInfo;


### PR DESCRIPTION
With the "Network Session 1" (Network MIDI session) the manufacturer is empty and causes an exception.
